### PR TITLE
Allow chained CSS classes

### DIFF
--- a/js/bgPicker.controller.js
+++ b/js/bgPicker.controller.js
@@ -95,7 +95,7 @@ angular.module("umbraco").controller("bgPicker.Controller", function ($scope, $h
 
 	// 
 	$scope.render = function (currentClassName) {
-		return $scope.pattern.replace("{0}", currentClassName);
+		return $scope.pattern.replace("{0}", currentClassName.replace(".", " "));
 	};
 
 	$scope.refresh = function() {


### PR DESCRIPTION
This fixes issue: #3 

In our SCSS Icon font file we have some icons defined like this:

```
.swicon-linkedin
{ 
    &:before {
    content: "\f0e1";
    }
    &.color:before {
        color: #0077b5 !important;
    }
}
```

This broke the display of the icons in the back office.

This pull requests allows the .color class to work correctly in the back office UI by removing the dots when adding to the class statement, this would also support multiple CSS classes, eg. the icon, color & size.

You can see in the screen shot how this is working:

![screenshot 39](https://user-images.githubusercontent.com/4398217/49024133-ccd0e300-f166-11e8-9190-cdae8bd94032.png)

To summarize:

Before:

class="icon.color"

After:

class="icon color"